### PR TITLE
Memoize add/remove/removeAll

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -77,7 +77,7 @@ function Notification(props) {
     return (): void => {
       clearTimeout(timeout);
     };
-  }, [duration]);
+  }, [id, duration, notifications.remove]);
 
   return (
     <div

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,10 @@
-import React, { useState, createContext, useContext } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useState,
+  createContext,
+  useContext,
+} from 'react';
 
 /**
  * Represents a queued item. The ID is used internally to reference every notification. The generic types is intended
@@ -54,38 +60,47 @@ export interface QueueHook<T> {
  *      }
  */
 export function useQueue<T>(initialValue: ImmutableQueue<T>): QueueHook<T> {
-  const [queue, setQueue] = useState(initialValue);
+  const [{ entries }, setQueue] = useState(initialValue);
 
-  return {
-    /**
-     * Add a new notification to the queue. If the ID already exists it will updated.
-     * @param id Unique string identifier for notification.
-     * @param data
-     */
-    add(id: string, data: T): void {
+  /**
+   * Add a new notification to the queue. If the ID already exists it will updated.
+   * @param id Unique string identifier for notification.
+   * @param data
+   */
+  const add = useCallback(
+    (id: string, data: T): void => {
       setQueue(queue => queue.add(id, data));
     },
+    [setQueue]
+  );
 
-    /**
-     * Remove a notification by ID
-     * @param id Unique string identifier for a notification
-     */
-    remove(id: string): void {
+  /**
+   * Remove a notification by ID
+   * @param id Unique string identifier for a notification
+   */
+  const remove = useCallback(
+    (id: string): void => {
       setQueue(queue => queue.remove(id));
     },
+    [setQueue]
+  );
 
-    /**
-     * Remove all notifications from the page.
-     */
-    removeAll(): void {
-      setQueue(queue => queue.removeAll());
-    },
+  /**
+   * Remove all notifications from the page.
+   */
+  const removeAll = useCallback((): void => {
+    setQueue(queue => queue.removeAll());
+  }, [setQueue]);
 
-    /**
-     * The current array of notifications.
-     */
-    entries: queue.entries,
-  };
+  return useMemo(
+    () => ({
+      add,
+      remove,
+      removeAll,
+      entries,
+    }),
+    [add, remove, removeAll, entries]
+  );
 }
 
 /**

--- a/test/queue-hook.test.tsx
+++ b/test/queue-hook.test.tsx
@@ -50,4 +50,28 @@ describe('useQueue', () => {
 
     expect(result.current.entries.length).toEqual(0);
   });
+
+  it('should memoize add/remove/removeAll', () => {
+    const { result } = renderHook(() =>
+      useQueue<Notification>(createImmutableQueue())
+    );
+
+    const { add, remove, removeAll } = result.current;
+
+    act(() => {
+      result.current.add('test', { message: 'test' });
+    });
+
+    expect(result.current.add).toBe(add);
+    expect(result.current.remove).toBe(remove);
+    expect(result.current.removeAll).toBe(removeAll);
+
+    act(() => {
+      result.current.remove('test');
+    });
+
+    expect(result.current.add).toBe(add);
+    expect(result.current.remove).toBe(remove);
+    expect(result.current.removeAll).toBe(removeAll);
+  });
 });


### PR DESCRIPTION
The `add`/`remove`/`removeAll` functions need to be memoized to avoid unnecessary rerendering and incorrect behavior when removing a notification with a delay using `useEffect` with exhaustive effect dependencies specified via the `deps` array.