### PR TITLE
Add "onRemove" callback argument to "add" function

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -6,7 +6,6 @@ import { createNotificationContext } from '../.';
 
 interface Notification {
   message: string;
-  duration:
 }
 
 const {
@@ -18,10 +17,9 @@ function Button() {
   const notifications = useNotificationQueue();
 
   function addNotification() {
-    notifications.add(Date.now().toString(), {
-      message: 'Hello',
-      duration: 3000
-    });
+    const id = Date.now().toString();
+    const timeout = setTimeout(() => notifications.remove(id), 3000);
+    notifications.add(id, { message: 'Hello' }, () => clearTimeout(timeout));
   }
 
   function clearAll() {
@@ -58,7 +56,7 @@ function NotificationList() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, scale: 0.5, transition: { duration: 0.2 } }}
           >
-            <Notification id={id} message={data.message} duration={data.duration} />
+            <Notification message={data.message} />
           </motion.div>
         ))}
       </AnimatePresence>
@@ -66,19 +64,7 @@ function NotificationList() {
   );
 }
 
-function Notification(props) {
-  const { id, message, duration } = props;
-  const notifications = useNotificationQueue();
-
-  React.useEffect(() => {
-    const timeout = setTimeout(() => {
-      notifications.remove(id);
-    }, duration);
-    return (): void => {
-      clearTimeout(timeout);
-    };
-  }, [id, duration, notifications.remove]);
-
+function Notification({ message }) {
   return (
     <div
       style={{

--- a/test/immutable-queue.test.tsx
+++ b/test/immutable-queue.test.tsx
@@ -40,4 +40,41 @@ describe('createImmutableQueue', () => {
 
     expect(q6.entries.length).toEqual(0);
   });
+
+  it('should call the onRemove callback when removing a notification', () => {
+    const onRemoveCalls: string[] = [];
+
+    const reset = () => {
+      onRemoveCalls.splice(0, onRemoveCalls.length);
+    };
+
+    const onRemove = (id: string) => () => {
+      onRemoveCalls.push(id);
+    };
+
+    const q1 = createImmutableQueue<Notification>();
+
+    const q2 = q1.add('test', { message: 'test' }, onRemove('test'));
+
+    expect(onRemoveCalls).toEqual([]);
+
+    q2.remove('test');
+
+    expect(onRemoveCalls).toEqual(['test']);
+
+    reset();
+
+    const q3 = createImmutableQueue<Notification>();
+
+    // Add multiple
+    const q4 = q3
+      .add('test', { message: 'test' }, onRemove('test'))
+      .add('test2', { message: 'test' }, onRemove('test2'));
+
+    expect(onRemoveCalls).toEqual([]);
+
+    q4.removeAll();
+
+    expect(onRemoveCalls).toEqual(['test', 'test2']);
+  });
 });

--- a/test/mock-immutable-queue.test.tsx
+++ b/test/mock-immutable-queue.test.tsx
@@ -36,4 +36,41 @@ describe('createMockImmutableQueue', () => {
 
     expect(queue.entries.length).toEqual(0);
   });
+
+  it('should call the onRemove callback when removing a notification', () => {
+    const onRemoveCalls: string[] = [];
+
+    const reset = () => {
+      onRemoveCalls.splice(0, onRemoveCalls.length);
+    };
+
+    const onRemove = (id: string) => () => {
+      onRemoveCalls.push(id);
+    };
+
+    const q1 = createMockImmutableQueue<Notification>();
+
+    const q2 = q1.add('test', { message: 'test' }, onRemove('test'));
+
+    expect(onRemoveCalls).toEqual([]);
+
+    q2.remove('test');
+
+    expect(onRemoveCalls).toEqual(['test']);
+
+    reset();
+
+    const q3 = createMockImmutableQueue<Notification>();
+
+    // Add multiple
+    const q4 = q3
+      .add('test', { message: 'test' }, onRemove('test'))
+      .add('test2', { message: 'test' }, onRemove('test2'));
+
+    expect(onRemoveCalls).toEqual([]);
+
+    q4.removeAll();
+
+    expect(onRemoveCalls).toEqual(['test', 'test2']);
+  });
 });

--- a/test/notification-provider.test.tsx
+++ b/test/notification-provider.test.tsx
@@ -131,9 +131,13 @@ describe('NotificationProvider', () => {
       fireEvent.click(addButton);
     });
 
-    expect(addNotification).toHaveBeenCalledWith('test', {
-      message: 'test',
-    });
+    expect(addNotification).toHaveBeenCalledWith(
+      'test',
+      {
+        message: 'test',
+      },
+      undefined
+    );
 
     act(() => {
       fireEvent.click(removeButton);

--- a/test/queue-hook.test.tsx
+++ b/test/queue-hook.test.tsx
@@ -74,4 +74,54 @@ describe('useQueue', () => {
     expect(result.current.remove).toBe(remove);
     expect(result.current.removeAll).toBe(removeAll);
   });
+
+  it('should call the onRemove callback when removing a notification', () => {
+    const onRemoveCalls: string[] = [];
+
+    const reset = () => {
+      onRemoveCalls.splice(0, onRemoveCalls.length);
+    };
+
+    const onRemove = (id: string) => () => {
+      onRemoveCalls.push(id);
+    };
+
+    {
+      const { result } = renderHook(() =>
+        useQueue<Notification>(createImmutableQueue())
+      );
+      act(() => {
+        result.current.add('test', { message: 'test' }, onRemove('test'));
+      });
+
+      expect(onRemoveCalls).toEqual([]);
+      act(() => {
+        result.current.remove('test');
+      });
+
+      expect(onRemoveCalls).toEqual(['test']);
+    }
+
+    reset();
+
+    {
+      const { result } = renderHook(() =>
+        useQueue<Notification>(createImmutableQueue())
+      );
+
+      // Add multiple
+      act(() => {
+        result.current.add('test', { message: 'test' }, onRemove('test'));
+        result.current.add('test2', { message: 'test' }, onRemove('test2'));
+      });
+
+      expect(onRemoveCalls).toEqual([]);
+
+      act(() => {
+        result.current.removeAll();
+      });
+
+      expect(onRemoveCalls).toEqual(['test', 'test2']);
+    }
+  });
 });


### PR DESCRIPTION
After remembering

> You may rely on useMemo as a performance optimization, not as a semantic guarantee. In the future, React may choose to “forget” some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. Write your code so that it still works without useMemo — and then add it to optimize performance.
>
> -- https://reactjs.org/docs/hooks-reference.html#usememo

I'm not sure !5 addressed the problem I was trying to solve in the right way.

When a notification component uses an effect to auto-remove the notification from the queue after a delay of a few seconds and when another notification gets added to the queue before the previous one is removed, the effect is disposed and a new one is created, effectively resetting the delay ‒ at least when satisfying the `exhaustive-deps` rule of [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks). Specifically, at least the `remove` function would need be a `useEffect` dependency which would change when, e.g., a new notification is added unless is is memoized thanks to `useCallback`. Since `useMemo`/`useCallback` should only be considered an optimization but not be relied upon for correctness, !5 should only be considered a performance optimization (if at all ‒ I just stumbled over https://kentcdodds.com/blog/usememo-and-usecallback where Kent Dodds argues that the overhead of `useMemo` and `useCallback` often outweighs the sought savings).

I think it is better to move the removal logic to the event callback that adds a notification to the queue instead of using an effect in the component that renders the notification for the reasons stated above. @anthonyshort What do you think?